### PR TITLE
Add VRC Hub to README under free tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ Sections ordered alpabetically
 
 #### Free (closed source)
   * [Automation for vMix (by Step Back In Time TV)](http://www.stepbackintime.tv/automation.html) (previously a paid software product)
-  * [VRC Hub (Video Recording Control) - by Kotin-ak](https://github.com/Kotin-ak/VRC-Releases) - A native Windows dashboard to monitor Rec/Stream status, CPU/GPU, and disk space for multiple vMix machines simultaneously.
   * [HTTP Matrix - Super basic vMix scheduler - by Eric Pratt](http://usbroadcast.co/httpmatrix.htm)
   * [TimeCode Reader for Production Back-Timing Reference - by Raugert](https://forums.vmix.com/posts/t17782-TimeCode-Reader-for-Production-Back-Timing-Reference?fbclid=IwAR0KYOl1gePpt4xsMSJ0PX_NlQbjFu1PIV6wJg3RTWe9YYp8Nzr2SU1wMXA)
   * [vMix Alt-Tally - by Jens Stigaard](https://forums.vmix.com/posts/t9405--FREE--Alt-Tally)
   * [vMix Panel Builder Software - by Raugert](https://forums.vmix.com/posts/t14529-vMix--Panel-Builder--for-Mac-Win-Android-tablets-iPads)
   * [Vrac - Remote Audio Controller for vMix](https://forums.vmix.com/posts/t25619--FREE--Vrac---Remote-Audio-Controller-for-Vmix)
+  * [VRC Hub (Video Recording Control) - by Kotin-ak](https://github.com/Kotin-ak/VRC-Releases) - A native Windows dashboard to monitor Rec/Stream status, CPU/GPU, and disk space for multiple vMix machines simultaneously.
 
 
 #### Paid / Licensed

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Sections ordered alpabetically
 
 #### Free (closed source)
   * [Automation for vMix (by Step Back In Time TV)](http://www.stepbackintime.tv/automation.html) (previously a paid software product)
+  * [VRC Hub (Video Recording Control) - by Kotin-ak](https://github.com/Kotin-ak/VRC-Releases) - A native Windows dashboard to monitor Rec/Stream status, CPU/GPU, and disk space for multiple vMix machines simultaneously.
   * [HTTP Matrix - Super basic vMix scheduler - by Eric Pratt](http://usbroadcast.co/httpmatrix.htm)
   * [TimeCode Reader for Production Back-Timing Reference - by Raugert](https://forums.vmix.com/posts/t17782-TimeCode-Reader-for-Production-Back-Timing-Reference?fbclid=IwAR0KYOl1gePpt4xsMSJ0PX_NlQbjFu1PIV6wJg3RTWe9YYp8Nzr2SU1wMXA)
   * [vMix Alt-Tally - by Jens Stigaard](https://forums.vmix.com/posts/t9405--FREE--Alt-Tally)


### PR DESCRIPTION
Added VRC Hub to the list of free (closed source) tools. Hi! I've developed a native Windows dashboard (Freeware) for monitoring multiple vMix machines simultaneously via the vMix API. It tracks Rec/Stream status, hardware alerts (CPU/GPU, low disk space), and audio buses. I believe it would be a helpful addition to the "Free (closed source)" section for users managing complex or REMI setups. Thank you!